### PR TITLE
WIP Key Service For Django

### DIFF
--- a/dborutils/__init__.py
+++ b/dborutils/__init__.py
@@ -3,4 +3,4 @@
 
 __author__ = 'Josvic Zammit'
 __email__ = 'jvzammit@gmail.com'
-__version__ = '0.2.2'
+__version__ = '0.3.0'

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ history = open('HISTORY.md').read().replace('.. :changelog:', '')
 
 setup(
     name='dborutils',
-    version='0.2.2',
+    version='0.3.0',
     description='DBOR Utilities contains shared classes related to our Database of Record Project',
     long_description=readme + '\n\n' + history,
     author='Josvic Zammit',


### PR DESCRIPTION
Hey @rlepore and @jvzammit ... for review and collaboration...,

This is what I have so far. The branch doesn't work yet because NoodleProfile isn't importable here.

@jvzammit can you figure out a way to make it available in a reusable way?

The usage would be:

``` python
# category_prefix == NoodleProfile.primary_category.code for the instance
nice_key = NoodleDjangoModelKeyService().generate_nice_key(prefix=category_prefix)
```

@rlepore 
Your mongo usage would look like this:

``` python
client = NoodleMongoClient("dbor_mongo.noodle.org:production:tutors")
nice_key = NoodleKeyService(source_client=client).generate_nice_key(prefix=category_prefix)
```
