### PR TITLE
`MongoCollection.__init__` survives a collection without `self.key`

### DIFF
--- a/dborutils/mongo.py
+++ b/dborutils/mongo.py
@@ -74,8 +74,11 @@ class MongoCollection(AbstractDocumentCollection):
         documents = self.mongo.find(pm_filter, {self.key: 1})
         self._provider_managed_keys = {d[self.key] for d in documents}
 
-        self.key_to_mongo_id = {d[self.key]: d["_id"] \
-            for d in self.mongo.find(self.filter, {self.key: 1})}
+        self.key_to_mongo_id = {
+            d[self.key]: d["_id"]
+                for d in self.mongo.find(self.filter, {self.key: 2})
+                if self.key in d
+        }
 
     def count(self):
         return self.mongo.find(self.filter, {self.key: 1}).count()


### PR DESCRIPTION
For some reason some records in mongo's school collection do not have a
`self.key` (nice_key). Checking for existence before using it in the
dictionary comprehension.

Note: This is should be consider as duck tape around existing code. I
can't find a logical reason for having School without nice_key.