### PR TITLE
Put NICE_KEY_MAX_LENGTH in dborutils so it can sync across repos

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include HISTORY.md
+include LICENSE
+include README.md

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include HISTORY.md
 include LICENSE
 include README.md

--- a/dborutils/__init__.py
+++ b/dborutils/__init__.py
@@ -3,4 +3,4 @@
 
 __author__ = 'Noodle'
 __email__ = 'data@noodle.com'
-__version__ = '0.4.5'
+__version__ = '0.4.6'

--- a/dborutils/key_service.py
+++ b/dborutils/key_service.py
@@ -1,6 +1,6 @@
 from uuid import uuid1
 from uuid import uuid4
-from numpy import base_repr
+from numpy_excerpt import base_repr
 
 
 # Changing this will require DB migrations in both dbor_wip and

--- a/dborutils/key_service.py
+++ b/dborutils/key_service.py
@@ -3,6 +3,12 @@ from uuid import uuid4
 from numpy import base_repr
 
 
+# Changing this will require DB migrations in both dbor_wip and
+# noodle-api!!!  Do not reduce below the longest existing nice_keys
+# across all tables!!!
+NICE_KEY_MAX_LENGTH = 20
+
+
 class NoodleKeyService(object):
 
     # This INCLUDES the two-character prefix!

--- a/dborutils/numpy_excerpt.py
+++ b/dborutils/numpy_excerpt.py
@@ -1,0 +1,56 @@
+# Copied from core/numeric.py in numpy 1.10.1 to avoid having all of
+# numpy as a dependency
+
+
+def base_repr(number, base=2, padding=0):
+    """
+    Return a string representation of a number in the given base system.
+
+    Parameters
+    ----------
+    number : int
+        The value to convert. Only positive values are handled.
+    base : int, optional
+        Convert `number` to the `base` number system. The valid range is 2-36,
+        the default value is 2.
+    padding : int, optional
+        Number of zeros padded on the left. Default is 0 (no padding).
+
+    Returns
+    -------
+    out : str
+        String representation of `number` in `base` system.
+
+    See Also
+    --------
+    binary_repr : Faster version of `base_repr` for base 2.
+
+    Examples
+    --------
+    >>> np.base_repr(5)
+    '101'
+    >>> np.base_repr(6, 5)
+    '11'
+    >>> np.base_repr(7, base=5, padding=3)
+    '00012'
+
+    >>> np.base_repr(10, base=16)
+    'A'
+    >>> np.base_repr(32, base=16)
+    '20'
+
+    """
+    digits = '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ'
+    if base > len(digits):
+        raise ValueError("Bases greater than 36 not handled in base_repr.")
+
+    num = abs(number)
+    res = []
+    while num:
+        res.append(digits[num % base])
+        num //= base
+    if padding:
+        res.append('0' * padding)
+    if number < 0:
+        res.append('-')
+    return ''.join(reversed(res or '0'))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,8 @@
 # Keep in sync with setup.py!
 pymongo==2.7.1
 wheel==0.26.0
+
+# For testing
+flake8==2.4.1
+mock==1.3.0
+nose==1.3.7

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 # Keep in sync with setup.py!
 pymongo==2.7.1
 wheel==0.26.0
-numpy==1.10.1

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ readme = open('README.md').read()
 
 setup(
     name='dborutils',
-    version='0.4.5',
+    version='0.4.6',
     description='DBOR Utilities contains code shared between multiple Noodle repositories.',
     long_description=readme,
     author='Noodle',

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,6 @@ setup(
     install_requires=[
         'pymongo==2.7.1',
         'wheel==0.26.0',
-        'numpy==1.10.1',
     ],
     license="BSD",
     zip_safe=False,

--- a/tests/test_dborutils.py
+++ b/tests/test_dborutils.py
@@ -7,6 +7,7 @@ Tests for the dborutils repo.
 import re
 from mock import patch
 from unittest import TestCase
+import unittest
 
 from dborutils.mongo_client import NoodleMongoClient
 from dborutils.key_service import NoodleKeyService
@@ -82,3 +83,6 @@ class TestDborutils(TestCase):
         nks = NoodleKeyService()
         test_key = nks.generate_nice_key(prefix="yz")
         self.assertTrue(re.match("yz\w\w\w\w\w\w\w\w\w\w", test_key))
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_dborutils.py
+++ b/tests/test_dborutils.py
@@ -1,22 +1,18 @@
-#!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
 """
-test_dborutils
-----------------------------------
-
-Tests for `dborutils` module.
+Tests for the dborutils repo.
 """
 
-import unittest
+import re
+from mock import patch
+from unittest import TestCase
 
 from dborutils.mongo_client import NoodleMongoClient
+from dborutils.key_service import NoodleKeyService
 
 
-class TestDborutils(unittest.TestCase):
-
-    def setUp(self):
-        pass
+class TestDborutils(TestCase):
 
     def test_parse_argstring_without_user_pass(self):
         mongo_spec = '127.0.0.1:local:categories'
@@ -78,8 +74,11 @@ class TestDborutils(unittest.TestCase):
         with self.assertRaises(Exception):
             NoodleMongoClient.parse_db_argstring(mongo_spec)
 
-    def tearDown(self):
-        pass
+    def fake_is_unique(self, candidate_nice_key):
+        return True
 
-if __name__ == '__main__':
-    unittest.main()
+    @patch('dborutils.key_service.NoodleKeyService._is_nice_key_unique')
+    def test_key_service(self, fake_is_unique):
+        nks = NoodleKeyService()
+        test_key = nks.generate_nice_key(prefix="yz")
+        self.assertTrue(re.match("yz\w\w\w\w\w\w\w\w\w\w", test_key))

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26, py27, py33
+envlist = py27, py33
 
 [testenv]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33
+envlist = py27
 
 [testenv]
 setenv =


### PR DESCRIPTION
Sorry for yet another of these, but this is required for
https://github.com/NoodleEducation/noodle-api/pull/2461
https://github.com/NoodleEducation/dbor_wip/pull/1711

nice_key lengths were all over the place in noodle-api, with the lowest being 10.  It's now mandatory that I increase the key lengths there, so I'm doing them the same everywhere, dammit, with a single control knob right next to the code that assigns nice_keys.